### PR TITLE
Fix 'Split' interfaces classes, update library version to v0.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.12]
 
-### Added
+### Fixed
 
-- Added interface class references to 'Split' class interfaces
+- Fix 'Split' interfaces classes
 
 ## [0.0.11]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.12]
+
+### Added
+
+- Added interface class references to 'Split' class interfaces
+
 ## [0.0.11]
 
 ### Added

--- a/NorsokSCDLibrary.aml
+++ b/NorsokSCDLibrary.aml
@@ -1,7 +1,7 @@
 ﻿<CAEXFile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.dke.de/CAEX" SchemaVersion="3.0" FileName="NorsokSCDLibrary.aml" xsi:schemaLocation="http://www.dke.de/CAEX CAEX_ClassModel_V.3.0.xsd">
   <!-- reference to Whitepaper Part1 -->
   <AdditionalInformation DocumentVersions="Recommendations">
-    <Document DocumentIdentifier="IEC63131AmlLibrary" Version="0.0.11" />
+    <Document DocumentIdentifier="IEC63131AmlLibrary" Version="0.0.12" />
   </AdditionalInformation>
   <SuperiorStandardVersion>AutomationML 2.10</SuperiorStandardVersion>
   <InterfaceClassLib Name="InterfaceClassLibrary">
@@ -17453,7 +17453,7 @@
             <DefaultValue />
             <Value>S</Value>
           </Attribute>
-          <ExternalInterface Name="X" ID="c8a36330-9f04-6147-8da3-69bd7aa43c7d">
+          <ExternalInterface Name="X" ID="c8a36330-9f04-6147-8da3-69bd7aa43c7d" RefBaseClassPath="InterfaceClassLibrary/NorsokSignalClass/In">
             <Description>External function input</Description>
             <Attribute Name="Direction" AttributeDataType="xs:string">
               <Description />
@@ -17500,7 +17500,7 @@
               </Constraint>
             </Attribute>
           </ExternalInterface>
-          <ExternalInterface Name="Y1" ID="b8c1f222-4b1a-f943-a521-2725648f336e">
+          <ExternalInterface Name="Y1" ID="b8c1f222-4b1a-f943-a521-2725648f336e" RefBaseClassPath="InterfaceClassLibrary/NorsokSignalClass/Out">
             <Description>Normal function output</Description>
             <Attribute Name="Direction" AttributeDataType="xs:string">
               <Description />
@@ -17535,7 +17535,7 @@
               </Constraint>
             </Attribute>
           </ExternalInterface>
-          <ExternalInterface Name="Y2" ID="7bef434c-997e-9541-ba4a-ca2e7cc18a26">
+          <ExternalInterface Name="Y2" ID="7bef434c-997e-9541-ba4a-ca2e7cc18a26" RefBaseClassPath="InterfaceClassLibrary/NorsokSignalClass/Out">
             <Description>Normal function output</Description>
             <Attribute Name="Direction" AttributeDataType="xs:string">
               <Description />


### PR DESCRIPTION
Fixed 'Split' interface classes.
Updated library version to 0.0.12
Closes #83 