### PR TITLE
Fix wrong type and class of InputParameter terminal Y

### DIFF
--- a/NorsokSCDLibrary.aml
+++ b/NorsokSCDLibrary.aml
@@ -15711,7 +15711,12 @@
             <Description />
             <DefaultValue />
             <Value>Analogue</Value>
-            <Constraint />
+            <Constraint Name="LegalValues">
+              <NominalScaledType>
+                <RequiredValue>Analogue</RequiredValue>
+                <RequiredValue>Binary</RequiredValue>
+              </NominalScaledType>
+            </Constraint>
           </Attribute>
           <Attribute Name="CommunicationType" AttributeDataType="xs:string">
             <Description>Type of signal communcication</Description>

--- a/NorsokSCDLibrary.aml
+++ b/NorsokSCDLibrary.aml
@@ -15709,8 +15709,8 @@
           </Attribute>
           <Attribute Name="SignalClass" AttributeDataType="xs:string">
             <Description />
-            <DefaultValue />
-            <Value>Analogue</Value>
+            <DefaultValue>Analogue</DefaultValue>
+            <Value />
             <Constraint Name="LegalValues">
               <NominalScaledType>
                 <RequiredValue>Analogue</RequiredValue>

--- a/NorsokSCDLibrary.aml
+++ b/NorsokSCDLibrary.aml
@@ -1,4 +1,4 @@
-<CAEXFile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.dke.de/CAEX" SchemaVersion="3.0" FileName="NorsokSCDLibrary.aml" xsi:schemaLocation="http://www.dke.de/CAEX CAEX_ClassModel_V.3.0.xsd">
+﻿<CAEXFile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.dke.de/CAEX" SchemaVersion="3.0" FileName="NorsokSCDLibrary.aml" xsi:schemaLocation="http://www.dke.de/CAEX CAEX_ClassModel_V.3.0.xsd">
   <!-- reference to Whitepaper Part1 -->
   <AdditionalInformation DocumentVersions="Recommendations">
     <Document DocumentIdentifier="IEC63131AmlLibrary" Version="0.0.12" />
@@ -15711,11 +15711,7 @@
             <Description />
             <DefaultValue />
             <Value>Analogue</Value>
-            <Constraint Name="LegalValues">
-              <NominalScaledType>
-                <RequiredValue>Analogue</RequiredValue>
-              </NominalScaledType>
-            </Constraint>
+            <Constraint />
           </Attribute>
           <Attribute Name="CommunicationType" AttributeDataType="xs:string">
             <Description>Type of signal communcication</Description>

--- a/NorsokSCDLibrary.aml
+++ b/NorsokSCDLibrary.aml
@@ -1,4 +1,4 @@
-﻿<CAEXFile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.dke.de/CAEX" SchemaVersion="3.0" FileName="NorsokSCDLibrary.aml" xsi:schemaLocation="http://www.dke.de/CAEX CAEX_ClassModel_V.3.0.xsd">
+<CAEXFile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.dke.de/CAEX" SchemaVersion="3.0" FileName="NorsokSCDLibrary.aml" xsi:schemaLocation="http://www.dke.de/CAEX CAEX_ClassModel_V.3.0.xsd">
   <!-- reference to Whitepaper Part1 -->
   <AdditionalInformation DocumentVersions="Recommendations">
     <Document DocumentIdentifier="IEC63131AmlLibrary" Version="0.0.12" />
@@ -15695,7 +15695,7 @@
           <DefaultValue />
           <Value />
         </Attribute>
-        <ExternalInterface Name="Y" RefBaseClassPath="InterfaceClassLibrary/NorsokSignalClass/Out/AnalogueOut" ID="6b2117e3-8475-7e4b-9309-fed0ce98bac7">
+        <ExternalInterface Name="Y" RefBaseClassPath="InterfaceClassLibrary/NorsokSignalClass/Out" ID="6b2117e3-8475-7e4b-9309-fed0ce98bac7">
           <Description>Normal function output</Description>
           <Attribute Name="Direction" AttributeDataType="xs:string">
             <Description />


### PR DESCRIPTION
### Fixed
- change InputParameter terminal Y type to NorsokSignalClass/Out
- allow also Binary SignalClass on terminal Y of InputParameter

Fixes #110